### PR TITLE
Revert changes from 4c58f6d1119ae

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -50,7 +50,7 @@ class UserProfile(models.Model):
             if actual_plot.current_tree():
                 recent_edits.append((actual_plot.current_tree().species, actual_plot.current_tree().date_planted, p.last_updated, p.id))
             else:
-                recent_edits.append(("", p.last_updated, p.last_updated, p.id))
+                recent_edits.append(("", p.last_updated, p.id))
         return sorted(recent_edits, key=itemgetter(2), reverse=True)[:7]
 
 

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -50,7 +50,7 @@ class UserProfile(models.Model):
             if actual_plot.current_tree():
                 recent_edits.append((actual_plot.current_tree().species, actual_plot.current_tree().date_planted, p.last_updated, p.id))
             else:
-                recent_edits.append(("", p.date_planted, p.last_updated, p.id))
+                recent_edits.append(("", p.last_updated, p.last_updated, p.id))
         return sorted(recent_edits, key=itemgetter(2), reverse=True)[:7]
 
 


### PR DESCRIPTION
The newly added `recently_edited_plots` method uses
fields that do not actually exist in the database.

Since I can't be 100% sure what these fields are actually for,
and the fact there is only one date field on a plot, I've
replaced the offending field (date_planted) with `last_updated`.
