### PR TITLE
Return only neighborhood info required

### DIFF
--- a/static/js/page_init.js
+++ b/static/js/page_init.js
@@ -16,9 +16,8 @@ tm.buildSpeciesList = function() {
 };
 
 tm.buildLocationList = function() {
-    $.getJSON(tm_static + 'neighborhoods/', {format:'json', list: 'list'}, function(nbhoods){
-        tm.locations = nbhoods;
-        tm.generateLocationDropdown(tm.locations);
+    $.getJSON(tm_static + 'neighborhoods/list/', {}, function(nbhoods){
+        tm.generateLocationDropdown(nbhoods);
     });
 };
 
@@ -232,9 +231,9 @@ tm.generateLocationDropdown = function(locations) {
     var ul = $("<ul id='n_list' style='max-height:180px; overflow:auto;'></ul>");
     $("#searchNBList").append(ul).hide();
     var states = {}
-    for(var i=0; i<locations.features.length;i++) {
-        var feature = locations.features[i];
-        var st_co = feature.properties.state + "-" + feature.properties.county;
+    for(var i=0; i<locations.length;i++) {
+        var feature = locations[i];
+        var st_co = feature.state + "-" + feature.county;
         if (!states[st_co])
         {
             states[st_co] = []
@@ -248,7 +247,7 @@ tm.generateLocationDropdown = function(locations) {
         for(i=0;i<entries.length;i++) {
             var c = "ac_odd";
             if (i%2 == 0) {c = 'ac-even';}
-            var name = entries[i].properties.name;
+            var name = entries[i].name;
             ul.append("<li id='" + name + "' class='" + c + "'>" + name + "</li>")
         }
     }
@@ -269,8 +268,8 @@ tm.generateLocationDropdown = function(locations) {
             select_nh.append("<option class='header' disabled='disabled'>" + state + " County</li>")
             var entries = states[state];
             for(i=0;i<entries.length;i++) {
-                var name = entries[i].properties.name;
-                var id = entries[i].properties.id;
+                var name = entries[i].name;
+                var id = entries[i].id;
                 select_nh.append("<option value='" + id + "' >" + name + "</li>")
             }
         }

--- a/treemap/urls.py
+++ b/treemap/urls.py
@@ -32,6 +32,7 @@ urlpatterns = patterns('',
     (r'^geocode/reverse/$', get_reverse_geocode),
     
     (r'^neighborhoods/$', geographies, {'model' : Neighborhood}),
+    (r'^neighborhoods/list/$', list_neighborhoods),
     (r'^neighborhoods/(?P<id>\d+)/$', geographies, {'model' : Neighborhood}),
     (r'^zipcodes/$', zips),
     (r'^zipcodes/(?P<id>\d+)/$', zips),

--- a/treemap/views.py
+++ b/treemap/views.py
@@ -80,6 +80,19 @@ def user_activated_callback(sender, **kwargs):
     #print rep
 user_activated.connect(user_activated_callback)
 
+def list_neighborhoods(request):
+    n = Neighborhood.objects.all().defer('geometry')
+    ns = []
+    for hood in n:
+        ns.append({
+            'name': hood.name,
+            'region_id': hood.region_id,
+            'city': hood.city,
+            'county': hood.county,
+            'state': hood.state })
+
+    return render_to_json(ns)
+
 #@cache_page(60*5)
 # Static pages have user information in them, so caching them doesn't work.
 def static(request, template, subdir="treemap"):


### PR DESCRIPTION
Previously, js was calling an endpoint the returned
a ton of extra geometry info that wasn't used. This
is a problem if you are working with high
resolution spatial data.

This commit creates a new endpoint that returns
all non-geospatial data
