### PR TITLE
Fix password reset template layouts

### DIFF
--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -1,16 +1,18 @@
-{% extends "base.html" %}
+{% extends "registration/base.html" %}
 {% load i18n %}
 
 {% block breadcrumbs %}<div class="breadcrumbs"><a href="../../">{% trans 'Home' %}</a> &rsaquo; {% trans 'Password reset' %}</div>{% endblock %}
 
 {% block title %}{% trans 'Password reset complete' %}{% endblock %}
 
-{% block content %}
+{% block left_panel %}
 
-<h1>{% trans 'Password reset complete' %}</h1>
+    <h1>{% trans 'Password reset complete' %}</h1>
 
-<p>{% trans "Your password has been set.  You may go ahead and log in now." %}</p>
+    <p>{% trans "Your password has been set.  You may go ahead and log in now." %}</p>
 
-<p><a href="{{ login_url }}">{% trans 'Log in' %}</a></p>
+    <p><a href="{{ login_url }}">{% trans 'Log in' %}</a></p>
 
 {% endblock %}
+
+

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,33 +1,35 @@
-{% extends "base.html" %}
+{% extends "registration/base.html" %}
 {% load i18n %}
 
 {% block breadcrumbs %}<div class="breadcrumbs"><a href="../">{% trans 'Home' %}</a> &rsaquo; {% trans 'Password reset confirmation' %}</div>{% endblock %}
 
 {% block title %}{% trans 'Password reset' %}{% endblock %}
 
-{% block content %}
+{% block left_panel %}
 
-{% if validlink %}
+    {% if validlink %}
+        <div id="register">
+            <h1>{% trans 'Enter a new password' %}</h1>
+            <div class="row">
+                <form id="form1" method="post" action="">
+                    <div style="height: 45px;">
+                        <label for="id_new_password1">{% trans 'New password:' %}<span id="smError2">Must be 6 characters or longer</span></label>
+                        {{ form.new_password1 }}
+                        <div style="color: red;">{{ form.new_password1.errors }}</div>
+                    </div>
+                    <div style="height: 45px;">
+                        <label for="id_new_password2">{% trans 'Confirm password:' %}<span id="smError2">Must match the previous field</span></label>{{ form.new_password2 }}
+                        <div style="color: red;">{{ form.new_password2.errors }}</div>
+                    </div>
 
-<div id="register">
-<h1>{% trans 'Enter new password' %}</h1>
-
-<p>{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
-
-<form action="" method="post">
-{{ form.new_password1.errors }}
-<p class="aligned wide"><label for="id_new_password1">{% trans 'New password:' %}</label>{{ form.new_password1 }}</p>
-{{ form.new_password2.errors }}
-<p class="aligned wide"><label for="id_new_password2">{% trans 'Confirm password:' %}</label>{{ form.new_password2 }}</p>
-<p><input type="submit" value="{% trans 'Change my password' %}" /></p>
-</form>
-
-{% else %}
-
-<h1>{% trans 'Password reset unsuccessful' %}</h1>
-
-<p>{% trans "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}
-</div>
-{% endif %}
+                    <button type="submit">Change my password</button>
+                    <div class="spacer"></div>
+                </form>
+            </div>
+        </div>
+    {% else %}
+        <h1>{% trans 'Password reset unsuccessful' %}</h1>
+        <p>{% trans "The password reset link was invalid, possibly because it has already been used.  Please request a new password reset." %}</p>
+    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
I modified the `password_reset_confirm.html` and `password_reset_complete.html` to inherit from registration/base rather than base so that they share a layout with the other registration pages.

I also reworked the password_reset_confirm markup:
- Removed unnecessary `<p>` tags.
- Styled the validation error text so that it is red and appears next to the appropriate field.
- Added "sub-label" detail text to the two field labels to match the appearance of the registration page.
