### PR TITLE
Fix benefit to dict conversion in API

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -21,10 +21,10 @@ from django.conf import settings
 from urlparse import urlparse
 import urllib
 from test_utils import setupTreemapEnv, teardownTreemapEnv, mkPlot, mkTree
-from treemap.models import Species, Plot, Tree, Pending, TreePending, PlotPending
+from treemap.models import Species, Plot, Tree, Pending, TreePending, PlotPending, TreeResource
 
 from api.models import APIKey, APILog
-from api.views import InvalidAPIKeyException, plot_or_tree_permissions, plot_permissions
+from api.views import InvalidAPIKeyException, plot_or_tree_permissions, plot_permissions, tree_resource_to_dict
 
 import struct
 import base64
@@ -1291,3 +1291,34 @@ class UpdatePlotAndTree(TestCase):
         self.assertEqual('failure', response_dict['status'], 'Expected "status" to be "failure"')
         self.assertTrue('detail' in response_dict, 'Expected "detail" to be a top level key in the response object')
         self.assertEqual('Username jim exists', response_dict['detail'])
+
+
+class Resource(TestCase):
+    def setUp(self):
+        setupTreemapEnv()
+
+    def tearDown(self):
+        teardownTreemapEnv()
+
+    def test_tree_resource_to_dict_on_empty_resource(self):
+        # If resources are all calculated as zero, this method should still return a valid object
+
+        tr = TreeResource()
+        tr.annual_stormwater_management = 0
+        tr.annual_electricity_conserved = 0
+        tr.annual_energy_conserved = 0
+        tr.annual_natural_gas_conserved = 0
+        tr.annual_air_quality_improvement = 0
+        tr.annual_co2_sequestered = 0
+        tr.annual_co2_avoided = 0
+        tr.annual_co2_reduced = 0
+        tr.total_co2_stored = 0
+        tr.annual_ozone = 0
+        tr.annual_nox = 0
+        tr.annual_pm10 = 0
+        tr.annual_sox = 0
+        tr.annual_voc = 0
+        tr.annual_bvoc = 0
+
+        resource_dict = tree_resource_to_dict(tr)
+        self.assertIsNotNone(resource_dict)

--- a/api/views.py
+++ b/api/views.py
@@ -906,7 +906,7 @@ def tree_resource_to_dict(tr):
         "annual_bvoc": with_unit(tr.annual_bvoc, b.bvoc, "lbs") }
     
 def with_unit(val,dollar_factor,unit,dollar=None):
-    if not dollar:
+    if dollar is None:
         dollar = dollar_factor * val
 
     return { "value": val, "unit": unit, "dollars": dollar }


### PR DESCRIPTION
A None value was creeping into a calculation because of an if check on
a numeric function parameter

```
if not dollar:
```

This will be true when dollar is None _and_ when dollar is 0.0 so I made
the if condition more explicit

```
if dollar is None:
```
