### PR TITLE
Inject i18n support for eco benefit values

### DIFF
--- a/static/treemap.js
+++ b/static/treemap.js
@@ -34,6 +34,8 @@ tm = {
 
     searchParams: {},
 
+    benefitUnitTransformer: function(k,v) { return v; },
+
     //initializes the map where a user places a new tree    
     get_icon: function(type, size) {
         var size = new OpenLayers.Size(size, size);
@@ -87,8 +89,8 @@ tm = {
         {
             $("#no_results").show();
         }   
-    },
-        
+    },         
+
     display_summaries : function(summaries){
         $(".tree_count").html(tm.addCommas(parseInt(summaries.total_trees)));
         $(".plot_count").html(tm.addCommas(parseInt(summaries.total_plots)));
@@ -100,11 +102,11 @@ tm = {
             $(".moretrees").html("");
             $(".notrees").html("");
         }
-        
         $.each(summaries, function(k,v){
             var span = $('#' + k);
             if (span.length > 0){
-                span.html(tm.addCommas(parseInt(v)));
+                span.html(tm.addCommas(
+                    tm.benefitUnitTransformer(k,parseInt(v))));
             }
         });
 

--- a/treemap/templatetags/tree_tags.py
+++ b/treemap/templatetags/tree_tags.py
@@ -6,6 +6,20 @@ from django.template import Library, Node
 from django.db.models import get_model
      
 register = Library()
+
+@register.filter
+def gal2litres(value):
+    if value:
+        return value * 3.78541
+    else:
+        return value
+
+@register.filter
+def lbs2kgs(value):
+    if value:
+        return value * 0.453592
+    else:
+        return value
      
 @register.filter
 def unit_or_missing(value, unit=None):


### PR DESCRIPTION
Add a new param to the tm object:
    `benefitUnitTransformer: function(k,v)''
This function returns`v'' untouched by default but allows
a skin (in map.js) to update the and transform the values

Additional US->UK conversions were added as tags:
gal2litres
lbs2kgs

Note that $->£ is done via the database (conversion factors
are in £)
