### PR TITLE
Allow for localized postal code fields

### DIFF
--- a/profiles/migrations/0002_auto__chg_field_userprofile_zip_code.py
+++ b/profiles/migrations/0002_auto__chg_field_userprofile_zip_code.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'UserProfile.zip_code'
+        db.alter_column('profiles_userprofile', 'zip_code', self.gf('django.db.models.fields.CharField')(max_length=20, null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'UserProfile.zip_code'
+        db.alter_column('profiles_userprofile', 'zip_code', self.gf('django.db.models.fields.CharField')(max_length=6, null=True))
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'profiles.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'site_edits': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'uid': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updates': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'}),
+            'volunteer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['profiles']

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -18,7 +18,7 @@ class UserProfile(models.Model):
     # not going to use volunteer, comment at a good moment...
     volunteer = models.BooleanField("Volunteer Opportunities",choices=BOOLEAN_CHOICES,default=False)
     updates = models.BooleanField('I would like to receive occasional email updates and newsletters',choices=BOOLEAN_CHOICES,default=False)
-    zip_code = models.CharField(max_length=6,null=True,blank=True)
+    zip_code = models.CharField(max_length=20,null=True,blank=True)
     photo = models.ImageField(upload_to='photos',height_field=None, width_field=None, max_length=200,null=True,blank=True)
     site_edits = models.IntegerField(_('Site Edits (to track activity)'),default=0,editable=False)
     uid = models.IntegerField(_('Random User ID'),null=True,blank=True,editable=False)

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -4,8 +4,8 @@ from django.contrib.auth.models import User
 from django.contrib.auth.models import SiteProfileNotAvailable
 from django.db.models import get_model
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.localflavor.us.forms import USZipCodeField
 from django_reputation.models import Reputation
+from treemap.localization import PostalCostField
 
 def get_profile_model():
     """
@@ -36,7 +36,7 @@ def get_profile_form():
     profile_mod = get_profile_model()
     class _ProfileForm(forms.ModelForm):
         email = forms.EmailField(widget=forms.TextInput(),label="Email address",required=False)
-        zip_code = USZipCodeField(required=False)
+        zip_code = PostalCostField(required=False)
         class Meta:
             model = profile_mod
             # planning to remove volunteer attr..

--- a/registration_backend/__init__.py
+++ b/registration_backend/__init__.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.contrib.localflavor.us.forms import USZipCodeField
 from django.core.exceptions import ObjectDoesNotExist
 
 from registration.backends.default import DefaultBackend
@@ -7,6 +6,7 @@ from registration.forms import RegistrationForm,RegistrationFormUniqueEmail
 from django.utils.translation import ugettext_lazy as _
 from profiles.models import UserProfile
 from django.db import transaction
+from treemap.localization import PostalCodeField
 
 class TreeRegistrationForm(RegistrationForm):
     volunteer = forms.BooleanField(required=False)
@@ -23,7 +23,7 @@ class TreeRegistrationForm(RegistrationForm):
                                 label=_("Last Name"),
                                 error_messages={ 'invalid': _("This value must contain only letters") },
                                 required=False)
-    zip_code = USZipCodeField(required=False)
+    zip_code = PostalCodeField(required=False)
     photo = forms.ImageField(required=False)
                                 
                                     

--- a/settings.py
+++ b/settings.py
@@ -1,12 +1,12 @@
 import os
 
 ADD_INITIAL_DEFAULTS = {}
+POSTAL_CODE_FIELD = "USZipCodeField"
 
 try:
    from impl_settings import *
 except ImportError, e:
    pass
-
 
 OTM_VERSION = "1.2"
 API_VERSION = "0.1"

--- a/static/js/geocode.js
+++ b/static/js/geocode.js
@@ -117,7 +117,11 @@ tm.reverse_geocode = function(ll, callback, error_callback){
                         if ($.inArray('locality', addy[i].types) > -1) {
                             city = addy[i].long_name;
                         }
-                        else if ($.inArray('postal_code', addy[i].types) > -1) {    
+                        // Some british postal codes just have a
+                        // prefix (i.e. E6) which isn't a fully valid
+                        // code
+                        else if ($.inArray('postal_code', addy[i].types) > -1 &&
+                                 $.inArray('postal_code_prefix', addy[i].types) == -1) {    
                             zip = addy[i].long_name;
                         }
                     }

--- a/treemap/forms.py
+++ b/treemap/forms.py
@@ -3,7 +3,7 @@ from models import Tree, Plot, Species, TreePhoto, TreeAlert, TreeAction, Neighb
 from shortcuts import get_add_initial
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.localflavor.us.forms import USZipCodeField
+from treemap.localization import PostalCostField
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from datetime import datetime
@@ -33,7 +33,7 @@ class TreeAddForm(forms.Form):
     edit_address_street = forms.CharField(max_length=200, required=True, initial=get_add_initial('address'))
     geocode_address = forms.CharField(widget=forms.HiddenInput, max_length=255, required=True)
     edit_address_city = forms.CharField(max_length=200, required=False, initial=get_add_initial('city'))
-    edit_address_zip = forms.CharField(max_length=50, required=False)
+    edit_address_zip = PostalCostField(required=False)
     lat = forms.FloatField(widget=forms.HiddenInput,required=True)
     lon = forms.FloatField(widget=forms.HiddenInput,required=True)
     initial_map_location = forms.CharField(max_length=200, required=False, widget=forms.HiddenInput)

--- a/treemap/localization.py
+++ b/treemap/localization.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+if settings.POSTAL_CODE_FIELD == "GBPostcodeField":
+   from django.contrib.localflavor.uk.forms import UKPostcodeField
+   PostalCodeField = UKPostcodeField
+else:
+   from django.contrib.localflavor.us.forms import USZipCodeField
+   PostalCodeField = USZipCodeField


### PR DESCRIPTION
Closes issue #38

Postal code types are now specified in settings as:
POSTAL_CODE_FIELD = "..."

And decoded into actual field values in "localization.py"
