### PR TITLE
Fix failures when settings.CHOICE_CONVERSIONS is not defined

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1374,14 +1374,17 @@ class ChoiceConversion(TestCase):
         public_user_auth = base64.b64encode("amy:password")
         self.public_user_sign = dict(self.public_user_sign.items() + [("HTTP_AUTHORIZATION", "Basic %s" % public_user_auth)])
 
-
     def tearDown(self):
         self._restore_choice_conversions()
         teardownTreemapEnv()
 
     def _setup_test_choice_conversions(self):
         self.original_choices = settings.CHOICES
-        self.original_choice_conversions = settings.CHOICE_CONVERSIONS
+        if hasattr(settings, 'CHOICE_CONVERSIONS'):
+            self.original_choice_conversions = settings.CHOICE_CONVERSIONS
+        else:
+            self.original_choice_conversions = None
+
         settings.CHOICES['conditions'] = [
                 ("10", "Good"),
                 ("11", "Bad")
@@ -1405,7 +1408,8 @@ class ChoiceConversion(TestCase):
 
     def _restore_choice_conversions(self):
         settings.CHOICES = self.original_choices
-        settings.CHOICE_CONVERSIONS = self.original_choice_conversions
+        if self.original_choice_conversions is not None:
+            settings.CHOICE_CONVERSIONS = self.original_choice_conversions
 
     def test_attribute_requires_conversion_when_no_version_is_specified(self):
         request = _create_mock_request_without_version()

--- a/api/views.py
+++ b/api/views.py
@@ -1205,7 +1205,12 @@ def _attribute_requires_conversion(request, attr):
     if attr is None:
         return False
 
-    if settings.CHOICE_CONVERSIONS and attr in settings.CHOICE_CONVERSIONS:
+    if not hasattr(settings, 'CHOICE_CONVERSIONS'):
+        # If CHOICE_CONVERSIONS is not defined in settings then
+        # no conversion is required
+        return False
+
+    if attr in settings.CHOICE_CONVERSIONS:
         conversion = settings.CHOICE_CONVERSIONS[attr]
         app_version = _parse_application_version_header_as_dict(request)
         if 'version-threshold' in conversion \
@@ -1218,8 +1223,8 @@ def _attribute_requires_conversion(request, attr):
             # or does not match anything
             return True
     else:
-        # If CHOICE_CONVERSIONS is not definied in settings or the CHOICE_CONVERSIONS
-        # hash does not contain the attribute name then no conversion is required
+        # If the settings.CHOICE_CONVERSIONS hash does not contain the attribute name
+        # then no conversion is required
         return False
 
 


### PR DESCRIPTION
The CHOICE_CONVERSIONS setting is completely optional but there were places
in the API code that expected the setting to exist.
