### PR TITLE
Lazily load localizations

### DIFF
--- a/treemap/localization.py
+++ b/treemap/localization.py
@@ -1,8 +1,9 @@
 from django.conf import settings
 
-if settings.POSTAL_CODE_FIELD == "GBPostcodeField":
-   from django.contrib.localflavor.uk.forms import UKPostcodeField
-   PostalCodeField = UKPostcodeField
-else:
-   from django.contrib.localflavor.us.forms import USZipCodeField
-   PostalCodeField = USZipCodeField
+def PostalCodeField(*args, **kwargs):
+    if settings.POSTAL_CODE_FIELD == "GBPostcodeField":
+        from django.contrib.localflavor.uk.forms import UKPostcodeField
+        return UKPostcodeField
+    else:
+        from django.contrib.localflavor.us.forms import USZipCodeField
+        return USZipCodeField

--- a/treemap/tests.py
+++ b/treemap/tests.py
@@ -25,6 +25,7 @@ from test_util import set_auto_now
 from treemap.test_choices import *
 
 settings.CHOICES = CHOICES
+settings.POSTAL_CODE_FIELD = "USZipCodeField"
 
 import django.shortcuts
 import tempfile


### PR DESCRIPTION
This allows us to ignore django initialization order, which was
wreaking havoc on our tests due to GB postal codes
