### PR TITLE
Create maths.py

### DIFF
--- a/treemap/templatetags/maths.py
+++ b/treemap/templatetags/maths.py
@@ -1,0 +1,23 @@
+from django import template
+register = template.Library()
+
+def float_add(value, arg):
+    "adds the arg and the value"
+    return value + arg
+
+def mult(value, arg):
+    "Multiplies the arg and the value"
+    return int(value) * int(arg)
+
+def sub(value, arg):
+    "Subtracts the arg from the value"
+    return int(value) - int(arg)
+
+def div(value, arg):
+    "Divides the value by the arg"
+    return int(value) / int(arg)
+
+register.filter('mult', mult)
+register.filter('sub', sub)
+register.filter('div', div)
+register.filter('float_add', float_add)


### PR DESCRIPTION
MATHS template tag missing from v1.2.
Given that v1.2 has no templates and that it's used within all city templates in OTM-master it should probably be included with 1.2.
