### PR TITLE
Update uimport.py

### DIFF
--- a/treemap/management/commands/uimport.py
+++ b/treemap/management/commands/uimport.py
@@ -7,9 +7,10 @@ from django.core.management.base import BaseCommand, CommandError
 from django.contrib.gis.geos import Point
 from django.contrib.gis.gdal import SpatialReference, CoordTransform
 from django.contrib.auth.models import User
-from OpenTreeMap.treemap.models import Species, Tree, Plot, Neighborhood, ZipCode, TreeFlags, ImportEvent
+from treemap.models import Species, Tree, Plot, Neighborhood, ZipCode, TreeFlags, ImportEvent
 
-from OpenTreeMap.choices import CHOICES as choices
+# Load CHOICES from your implementation-specific file (e.g. "from choices_SanDiego import *")
+from choices import CHOICES as choices
 
 class Command(BaseCommand):
     args = '<input_file_name, data_owner_id, base_srid, read_only>'


### PR DESCRIPTION
Removed hard-coded, case-sensitive "OpenTreeMap" references; Added a comment related to the current mechanism for specifying choices (implementation-specific file like "impl_chioces.sql" that's added to settings.py)
