### PR TITLE
Modify uimport script to use scientific name

### DIFF
--- a/treemap/management/commands/uimport.py
+++ b/treemap/management/commands/uimport.py
@@ -153,7 +153,7 @@ class Command(BaseCommand):
             if row.get('GENDER'):
                 gender = str(row['GENDER']).strip()
                 name = name + " " + gender
-            species = Species.objects.filter(genus__iexact=genus).filter(species__iexact=species).filter(cultivar_name__iexact=cultivar).filter(gender__iexact=gender)
+            species = Species.objects.filter(scientific_name__iexact=name)
             self.log_verbose("  Looking for species: %s %s %s %s" % (genus, species, cultivar, gender))
 
 


### PR DESCRIPTION
This script constructs a "name" from genus, species,
and cultivar in the check_species() function, but it
didn't actually use that constructed name to search for
species information from uimport csv's that have the scientific
name split up into separate fields.

The one line I changed here made the import process work for me, though I do not know if this is a change that should be committed to the main project. Can someone review this?
