### PR TITLE
Fix KML, CSV, Shapefile advanced search exports

### DIFF
--- a/treemap/export.py
+++ b/treemap/export.py
@@ -1,25 +1,14 @@
 # 
-# This module contains functions and views to be used for
+# This module contains functions to be used for
 # exporting data to various formats using ogr2ogr
 #
-# This is a pure python module. It can be tested by
-# running from the command-line by running:
-#
-# python export.py
-#
-# from the directory the file is located in.
 
 import re
 
-####################################
-## (PURE) PUBLIC FUNCTIONS
-####################################
-
 def sanitize_raw_sql(query):
     """
-    Takes a raw sql string and performs some dangerous sql surgery.
-
-    This fixes a big bug in the design of this app.
+    Takes a raw sql string and performs some sql surgery to
+    make queries valid on postgres
     """
     new_query = query
 
@@ -34,7 +23,7 @@ def sanitize_raw_sql(query):
     return new_query
 
 ####################################
-## (PURE) PRIVATE FUNCTIONS
+## PRIVATE FUNCTIONS
 ####################################
 
 def _quote_integers_in_pattern(pattern, query):
@@ -52,41 +41,3 @@ def _sanitize_native_status_field(query):
 def _sanitize_membership_test_field(field_name, query):
     pattern = '"%s" IN \([0-9, ]+\)' % field_name
     return _quote_integers_in_pattern(pattern, query)
-
-####################################
-## TESTS
-####################################
-
-def _test_condition_query():
-    condition_query = """
-SELECT "treemap_resourcesummarymodel"."id", "treemap_resourcesummarymodel"."annual_stormwater_management", "treemap_resourcesummarymodel"."annual_electricity_conserved", "treemap_resourcesummarymodel"."annual_energy_conserved", "treemap_resourcesummarymodel"."annual_natural_gas_conserved", "treemap_resourcesummarymodel"."annual_air_quality_improvement", "treemap_resourcesummarymodel"."annual_co2_sequestered", "treemap_resourcesummarymodel"."annual_co2_avoided", "treemap_resourcesummarymodel"."annual_co2_reduced", "treemap_resourcesummarymodel"."total_co2_stored", "treemap_resourcesummarymodel"."annual_ozone", "treemap_resourcesummarymodel"."annual_nox", "treemap_resourcesummarymodel"."annual_pm10", "treemap_resourcesummarymodel"."annual_sox", "treemap_resourcesummarymodel"."annual_voc", "treemap_resourcesummarymodel"."annual_bvoc", "treemap_treeresource"."resourcesummarymodel_ptr_id", "treemap_treeresource"."tree_id" FROM "treemap_treeresource" INNER JOIN "treemap_resourcesummarymodel" ON ("treemap_treeresource"."resourcesummarymodel_ptr_id" = "treemap_resourcesummarymodel"."id") WHERE "treemap_treeresource"."tree_id" IN (SELECT U0."id" FROM "treemap_tree" U0 WHERE (U0."present" = True  AND U0."condition" IN (3, 5, 7)))
-"""
-    condition_query = _sanitize_membership_test_field("condition", condition_query)
-    assert("('3', '5', '7')" in condition_query)
-
-def _test_multiple_fields_query():
-    condition_characteristic_query = """
-SELECT (
-            SELECT treemap_plot.geometry
-            FROM treemap_plot
-            WHERE treemap_tree.plot_id = treemap_plot.id
-            ) AS "geometry", "treemap_tree"."id", "treemap_tree"."plot_id", "treemap_tree"."tree_owner", "treemap_tree"."steward_name", "treemap_tree"."steward_user_id", "treemap_tree"."sponsor", "treemap_tree"."species_id", "treemap_tree"."species_other1", "treemap_tree"."species_other2", "treemap_tree"."orig_species", "treemap_tree"."dbh", "treemap_tree"."height", "treemap_tree"."canopy_height", "treemap_tree"."date_planted", "treemap_tree"."date_removed", "treemap_tree"."present", "treemap_tree"."last_updated", "treemap_tree"."last_updated_by_id", "treemap_tree"."s_order", "treemap_tree"."photo_count", "treemap_tree"."projects", "treemap_tree"."import_event_id", "treemap_tree"."condition", "treemap_tree"."canopy_condition", "treemap_tree"."readonly", "treemap_tree"."url", "treemap_tree"."pests" FROM "treemap_tree" WHERE ("treemap_tree"."present" = True  AND "treemap_tree"."condition" IN (2, 3, 4, 5, 6, 7) AND "treemap_tree"."species_id" IN (SELECT U0."id" FROM "treemap_species" U0 WHERE (U0."tree_count" > 0  AND U0."native_status" = True )))
-"""
-    new_condition_characteristic_query = _sanitize_native_status_field(condition_characteristic_query)
-    new_condition_characteristic_query = _sanitize_membership_test_field("condition", new_condition_characteristic_query)
-
-    assert('"native_status" = \'True\'' in new_condition_characteristic_query)
-    assert("('2', '3', '4', '5', '6', '7')" in new_condition_characteristic_query)
-
-    new_condition_characteristic_query = sanitize_raw_sql(condition_characteristic_query)
-    assert('"native_status" = \'True\'' in new_condition_characteristic_query)
-    assert("('2', '3', '4', '5', '6', '7')" in new_condition_characteristic_query)
-
-def _tests():
-    _test_condition_query()
-    _test_multiple_fields_query()
-    print "tests pass!"
-
-if __name__ == '__main__':
-    _tests()
-

--- a/treemap/export.py
+++ b/treemap/export.py
@@ -1,0 +1,92 @@
+# 
+# This module contains functions and views to be used for
+# exporting data to various formats using ogr2ogr
+#
+# This is a pure python module. It can be tested by
+# running from the command-line by running:
+#
+# python export.py
+#
+# from the directory the file is located in.
+
+import re
+
+####################################
+## (PURE) PUBLIC FUNCTIONS
+####################################
+
+def sanitize_raw_sql(query):
+    """
+    Takes a raw sql string and performs some dangerous sql surgery.
+
+    This fixes a big bug in the design of this app.
+    """
+    new_query = query
+
+    new_query = _sanitize_native_status_field(new_query)
+
+    for field in ("sidewalk_damage",
+                  "condition",
+                  "canopy_condition",
+                  "pests"):
+        new_query = _sanitize_membership_test_field(field, new_query)
+
+    return new_query
+
+####################################
+## (PURE) PRIVATE FUNCTIONS
+####################################
+
+def _quote_integers_in_pattern(pattern, query):
+    def quote_integer(matchobj):
+        return "'" + matchobj.group() + "'"
+
+    def quote_integers(matchobj):
+        return re.sub(r'(\d)', quote_integer, matchobj.group())
+
+    return re.sub(pattern, quote_integers, query)
+
+def _sanitize_native_status_field(query):
+    return query.replace('"native_status" = True', '"native_status" = \'True\'')
+
+def _sanitize_membership_test_field(field_name, query):
+    pattern = '"%s" IN \([0-9, ]+\)' % field_name
+    return _quote_integers_in_pattern(pattern, query)
+
+####################################
+## TESTS
+####################################
+
+def _test_condition_query():
+    condition_query = """
+SELECT "treemap_resourcesummarymodel"."id", "treemap_resourcesummarymodel"."annual_stormwater_management", "treemap_resourcesummarymodel"."annual_electricity_conserved", "treemap_resourcesummarymodel"."annual_energy_conserved", "treemap_resourcesummarymodel"."annual_natural_gas_conserved", "treemap_resourcesummarymodel"."annual_air_quality_improvement", "treemap_resourcesummarymodel"."annual_co2_sequestered", "treemap_resourcesummarymodel"."annual_co2_avoided", "treemap_resourcesummarymodel"."annual_co2_reduced", "treemap_resourcesummarymodel"."total_co2_stored", "treemap_resourcesummarymodel"."annual_ozone", "treemap_resourcesummarymodel"."annual_nox", "treemap_resourcesummarymodel"."annual_pm10", "treemap_resourcesummarymodel"."annual_sox", "treemap_resourcesummarymodel"."annual_voc", "treemap_resourcesummarymodel"."annual_bvoc", "treemap_treeresource"."resourcesummarymodel_ptr_id", "treemap_treeresource"."tree_id" FROM "treemap_treeresource" INNER JOIN "treemap_resourcesummarymodel" ON ("treemap_treeresource"."resourcesummarymodel_ptr_id" = "treemap_resourcesummarymodel"."id") WHERE "treemap_treeresource"."tree_id" IN (SELECT U0."id" FROM "treemap_tree" U0 WHERE (U0."present" = True  AND U0."condition" IN (3, 5, 7)))
+"""
+    condition_query = _sanitize_membership_test_field("condition", condition_query)
+    assert("('3', '5', '7')" in condition_query)
+
+def _test_multiple_fields_query():
+    condition_characteristic_query = """
+SELECT (
+            SELECT treemap_plot.geometry
+            FROM treemap_plot
+            WHERE treemap_tree.plot_id = treemap_plot.id
+            ) AS "geometry", "treemap_tree"."id", "treemap_tree"."plot_id", "treemap_tree"."tree_owner", "treemap_tree"."steward_name", "treemap_tree"."steward_user_id", "treemap_tree"."sponsor", "treemap_tree"."species_id", "treemap_tree"."species_other1", "treemap_tree"."species_other2", "treemap_tree"."orig_species", "treemap_tree"."dbh", "treemap_tree"."height", "treemap_tree"."canopy_height", "treemap_tree"."date_planted", "treemap_tree"."date_removed", "treemap_tree"."present", "treemap_tree"."last_updated", "treemap_tree"."last_updated_by_id", "treemap_tree"."s_order", "treemap_tree"."photo_count", "treemap_tree"."projects", "treemap_tree"."import_event_id", "treemap_tree"."condition", "treemap_tree"."canopy_condition", "treemap_tree"."readonly", "treemap_tree"."url", "treemap_tree"."pests" FROM "treemap_tree" WHERE ("treemap_tree"."present" = True  AND "treemap_tree"."condition" IN (2, 3, 4, 5, 6, 7) AND "treemap_tree"."species_id" IN (SELECT U0."id" FROM "treemap_species" U0 WHERE (U0."tree_count" > 0  AND U0."native_status" = True )))
+"""
+    new_condition_characteristic_query = _sanitize_native_status_field(condition_characteristic_query)
+    new_condition_characteristic_query = _sanitize_membership_test_field("condition", new_condition_characteristic_query)
+
+    assert('"native_status" = \'True\'' in new_condition_characteristic_query)
+    assert("('2', '3', '4', '5', '6', '7')" in new_condition_characteristic_query)
+
+    new_condition_characteristic_query = sanitize_raw_sql(condition_characteristic_query)
+    assert('"native_status" = \'True\'' in new_condition_characteristic_query)
+    assert("('2', '3', '4', '5', '6', '7')" in new_condition_characteristic_query)
+
+def _tests():
+    _test_condition_query()
+    _test_multiple_fields_query()
+    print "tests pass!"
+
+if __name__ == '__main__':
+    _tests()
+

--- a/treemap/tests.py
+++ b/treemap/tests.py
@@ -1551,7 +1551,7 @@ class ViewTests(TestCase):
         self.assertEqual(response['content-type'], 'application/zip')
         self.assertEqual(response['content-disposition'], 'attachment; filename=trees.zip')
         self.assertNotEqual(len(response.content), 0)
-        self.assert_zip_response_contains_files(response, ["trees.csv", "plots.csv", 'species.csv'])       
+        self.assert_zip_response_contains_files(response, ["eco.csv", "trees.csv", "plots.csv", 'species.csv'])
 
     def test_ogr_search_kml(self):
         response = self.client.get("/search/kml/")
@@ -1559,7 +1559,7 @@ class ViewTests(TestCase):
         self.assertEqual(response['content-type'], 'application/zip')
         self.assertEqual(response['content-disposition'], 'attachment; filename=trees.zip')
         self.assertNotEqual(len(response.content), 0)
-        self.assert_zip_response_contains_files(response, ["trees.kml", "plots.kml"])   
+        self.assert_zip_response_contains_files(response, ["eco.kml", "trees.kml", "plots.kml"])   
     
     def test_ogr_search_shp(self):
         response = self.client.get("/search/shp/")
@@ -1567,8 +1567,11 @@ class ViewTests(TestCase):
         self.assertEqual(response['content-type'], 'application/zip')
         self.assertEqual(response['content-disposition'], 'attachment; filename=trees.zip')
         self.assertNotEqual(len(response.content), 0)
-        self.assert_zip_response_contains_files(response, ["plots.dbf", "plots.prj", "plots.shp", 
-            "plots.shx", "trees.dbf", "trees.prj"])        
+        self.assert_zip_response_contains_files(response, [
+                "eco.dbf", "eco.prj", "eco.shp", "eco.shx",
+                "plots.dbf", "plots.prj", "plots.shp", 
+                "plots.shx", "trees.dbf", "trees.prj",
+                ])
 
     def test_ogr_comments_all_csv(self):
         # Test the admin-only exports

--- a/treemap/views.py
+++ b/treemap/views.py
@@ -44,6 +44,7 @@ from django.forms.models import inlineformset_factory, modelformset_factory
 from threadedcomments.models import ThreadedComment
 
 from search import search, DEFAULT_FILTERS
+from export import sanitize_raw_sql
 from models import *
 from forms import *
 from profiles.models import UserProfile
@@ -1624,13 +1625,13 @@ def advanced_search(request, format='json'):
         tree_query = "SELECT * FROM treemap_tree LIMIT 0";
         eco_query = "SELECT * FROM treemap_treeresource LIMIT 0";
     else:
-        tree_query = str(trees.query)
-        eco_query = str(TreeResource.objects.filter(tree__in=trees).query)
+        tree_query = sanitize_raw_sql(str(trees.query))
+        eco_query = sanitize_raw_sql(str(TreeResource.objects.filter(tree__in=trees).query))
 
     if plot_count == 0:
         plot_query = "SELECT * FROM treemap_plot LIMIT 0";
     else:
-        plot_query = str(plots.query)
+        plot_query = sanitize_raw_sql(str(plots.query))
 
     species_query = "SELECT * FROM treemap_species order by id asc"
 


### PR DESCRIPTION
Fixes Github Issue #76

Previously exports were only working for basic searches and were
broken for most advanced search filters. They now work for all
advanced search filters. Tested on TreeZilla.

The problem:
The advanced search routine builds up queryset for several models
and exports the queryset.query (raw sql query) to ogr2ogr, which
reruns the queries and exports to the aforementioned formats. The
problem is that Django is mishandling type coercions for certain
database fields that are stored as textual representations of other
values. For example, we store native_status as a varchar, but its
value is usually restricted to "True" or "False", which was being
sent to the querybuilder as True or False, the boolean values. The
other known example is integer values stored as varchars.

The Solution:
After discussing the possibility of enabling type coercion at the
database level, it was decided that a localized changed would be
safer than a global one. So, adding some functions that sanitize
the raw SQL that goes to ogr2ogr to be the correct textual string
instead of the represented value.
