### PR TITLE
Make recently_edited_plots return consistent data

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -50,7 +50,7 @@ class UserProfile(models.Model):
             if actual_plot.current_tree():
                 recent_edits.append((actual_plot.current_tree().species, actual_plot.current_tree().date_planted, p.last_updated, p.id))
             else:
-                recent_edits.append(("", p.last_updated, p.id))
+                recent_edits.append(("", None, p.last_updated, p.id))
         return sorted(recent_edits, key=itemgetter(2), reverse=True)[:7]
 
 


### PR DESCRIPTION
recently_edited_plots was returning a 3-tuple in some cases and a
4-tupe in others. Adding a null to make this more consistent for
downstream templates that call this function.

Reverses commit 01ca8bf55d70cde8af942a48f28e2271527a2c21
