### PR TITLE
Remove incomplete species name from CSV export

### DIFF
--- a/importer/views.py
+++ b/importer/views.py
@@ -478,8 +478,7 @@ def export_all_species(request):
 
     if include_extra_fields:
         extra_fields = (fields.species.ID,
-                        fields.species.TREE_COUNT,
-                        fields.species.SCIENTIFIC_NAME)
+                        fields.species.TREE_COUNT)
     else:
         extra_fields = tuple()
 


### PR DESCRIPTION
fixes the following reported issue:
"it looks like the scientific name column is just using data from the genus and species fields rather than genus, species, cultivar, and other part of scientific name. All four of those fields should contribute to the scientific name field. If that's not possible, then we need to remove the scientific name field from the export."
