### PR TITLE
Force CONTACT_EMAILS into a tuple

### DIFF
--- a/treemap/views.py
+++ b/treemap/views.py
@@ -1770,9 +1770,9 @@ def contact(request):
             if settings.FORCE_MAIL_TO_BE_FROM:
                 sender = settings.FORCE_MAIL_TO_BE_FROM
 
-            recipients = settings.CONTACT_EMAILS
+            recipients = tuple(settings.CONTACT_EMAILS)
             if cc_myself or settings.FORCE_MAIL_TO_BE_FROM:
-                recipients.append(sender)
+                recipients += (sender,)
 
             from django.core.mail import send_mail
             send_mail(subject, message, sender, recipients)


### PR DESCRIPTION
to fix a mutable state bug. settings is an immutable object, but settings.CONTACT_EMAILS was a list. Over the lifetime of the appserver process, this list was being mutated to contain ALL senders. This was causing all users that have used the contact form and requested a copy, to get EVERYONE's copy.
